### PR TITLE
Make the callback optional on writeDataCharacteristics

### DIFF
--- a/lib/noble-device.js
+++ b/lib/noble-device.js
@@ -75,7 +75,7 @@ NobleDevice.prototype.writeDataCharacteristic = function(serviceUuid, characteri
   var withoutResponse = (c.properties.indexOf('writeWithoutResponse') !== -1) &&
                         (c.properties.indexOf('write') === -1);
   this._characteristics[serviceUuid][characteristicUuid].write(data, withoutResponse, function(error) {
-    callback();
+    if (typeof callback === 'function') callback();
   });
 };
 


### PR DESCRIPTION
@sandeepmistry 

firmata sometimes calls the function write(data) without a callback parameter. The node-nRF8001 module handles this case by creating a dummy callback function and passing it on to writeDataCharacteristics. This change lets writeDataCharacteristics handle an optional callback so the nrfuart module can stop creating dummy callback functions.