### PR TITLE
Add disconnect listener in connect

### DIFF
--- a/lib/noble-device.js
+++ b/lib/noble-device.js
@@ -14,8 +14,6 @@ function NobleDevice(peripheral) {
   this.address = peripheral.address;
   this.addressType = peripheral.addressType;
   this.connectedAndSetUp = false;
-
-  this._peripheral.once('disconnect', this.onDisconnect.bind(this));
 }
 
 util.inherits(NobleDevice, events.EventEmitter);
@@ -32,7 +30,16 @@ NobleDevice.prototype.toString = function() {
 };
 
 NobleDevice.prototype.connect = function(callback) {
-  this._peripheral.connect(callback);
+
+  this._peripheral.connect(function(error) {
+    if (!error) {
+      this._peripheral.once('disconnect', this.onDisconnect.bind(this));
+    }
+    if (typeof(callback) === 'function') {
+      callback(error);
+    }
+  }.bind(this));
+
 };
 
 NobleDevice.prototype.disconnect = function(callback) {

--- a/test/test-noble-device.js
+++ b/test/test-noble-device.js
@@ -1,0 +1,72 @@
+var should = require('should');
+var NobleDevice = require('../index');
+
+describe('noble-device', function() {
+
+  this.timeout(20000); // Need plenty of time before timeout
+
+  var TestDevice = function (peripheral) {
+    NobleDevice.call(this, peripheral);
+  };
+
+  NobleDevice.Util.inherits(TestDevice, NobleDevice);
+
+  it('should not add a peripheral disconnect listener before connect', function (done) {
+    TestDevice.discover(function (testDevice) {
+      (testDevice._peripheral.listenerCount('disconnect')).should.be.exactly(0);
+      done();
+    });
+  });
+
+  it('should set a peripheral disconnect listener after connect', function (done) {
+    TestDevice.discover(function (testDevice) {
+      testDevice.connectAndSetup(function(error) {
+        (!!error).should.be.false;  // device used in test must accept connection
+        (testDevice._peripheral.listenerCount('disconnect')).should.be.exactly(1);
+        testDevice.disconnect();
+        done();
+      });
+    });
+  });
+
+  it('should not add a peripheral disconnect listener if connect fails', function (done) {
+    TestDevice.discover(function (testDevice) {
+      testDevice.connectAndSetup(function(error) {
+        (!!error).should.be.false;  // device used in test must accept connection
+        testDevice.connectAndSetup(function(error) {
+          (!!error).should.be.true;   // Already connected. Must return error.
+          (testDevice._peripheral.listenerCount('disconnect')).should.be.exactly(1);
+          testDevice.disconnect();
+          done();
+        });
+      });
+    });
+  });
+
+  it('should emit disconnect event on disconnection', function (done) {
+    TestDevice.discover(function (testDevice) {
+      testDevice.connectAndSetup(function(error) {
+        (!!error).should.be.false;  // device used in test must accept connection
+        testDevice.once('disconnect', function() {
+          done();
+        });
+        testDevice.disconnect();
+      });
+    });
+  });
+
+  it('should not throw an error if no callback is passed to connect', function(done) {
+    TestDevice.discover(function (testDevice) {
+      testDevice.connect();
+      // We do the following since we can't pass in a callback.
+      var intervalId = setInterval(wait, 500);
+      function wait() {
+        console.log(testDevice._peripheral.advertisement.localName + ' is ' + testDevice._peripheral.state );
+        if (testDevice._peripheral.state === "connected") {
+          clearInterval(intervalId);
+          done();
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
Prior version has a memory leak when the same device is discovered multiple times without connecting.

Changes:

Moves adding a 'disconnect' listener  from NobleDevice to the connect function. Also adds tests. Testing uses real bluetooth devices so testing success depends on what is around you and able to connect. Ideally this should be mocked.