### PR TITLE
lowercase-isation of the bluetooth address

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -116,7 +116,7 @@ Util.inherits = function(constructor, superConstructor) {
 
     constructor.discoverByAddress = function(address, callback) {
       constructor.discoverWithFilter(function(device) {
-        return (device.address === address);
+        return (device.address === address.toLowerCase());
       }, callback);
     };
   }


### PR DESCRIPTION
Hi, here is my PR to input only lowercased bluetooth address in the discoverByAddress function.
to ensure the underlying system will also always send a lower case address , i also made a PR for the noble/lib/hci-socket/hci.js : see : https://github.com/noble/noble/pull/794
